### PR TITLE
Fix synchronous failures not failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ perform a runtime assertion.
 
 ## Problem
 
-Asynchronous tests could be challenging to get _right_, particulrary for junior
+Asynchronous tests could be challenging to get _right_, particularly for junior
 developers or engineers new to async JavaScript. The most common mistake is an async
 test which does not fire any assertions, either due to logic or even syntax errors.
-Static analysis(linters) gets close to pointing out the issues, but is not enough to catch logic mistakes.
-For this, we require a runtime check that _some_ assertion was ran during the test.
+Static analysis (linters) gets close to pointing out the issues, but is not enough to catch logic mistakes.
+For this, we require a runtime check that _some_ assertion was run during the test.
 
 [Jest, unfortunately, has no "failWithoutAssertions" configuration options, so this plugin aims to remedy that.](https://github.com/facebook/jest/issues/2209)
 The plugin patches the Jest API to force tests without any assertions to fail. In addition
@@ -94,6 +94,6 @@ setupFilesAfterEnv: [
 
 ## Performance
 
-There is some performance implications of using this plugin as it does add a bit of
+There are some performance implications of using this plugin as it does add a bit of
 overhead, but from testing it's a trivial increase. This plugin has been tested
-within a project with 1600+ test suites and over 10k individual tests, with only a negligble slow-down.
+within a project with 1600+ test suites and over 10k individual tests, with only a negligible slow-down.

--- a/e2e/failing/__tests__/index.js
+++ b/e2e/failing/__tests__/index.js
@@ -5,6 +5,10 @@
 
 test('no assertions, no code', () => {});
 
+test('synchronous failure', () => {
+  expect(true).toBe(false);
+});
+
 test('missed runtime assertion', () => {
   const unused = () => expect(true).toBe(true);
 });
@@ -50,6 +54,10 @@ test('assertions after done() callback (jest bugfix)', done => {
 describe('it() blocks work as test()', () => {
   it('missed runtime assertion', () => {
     const unused = () => expect(true).toBe(true);
+  });
+
+  it('synchronous failure', () => {
+    expect(true).toBe(false);
   });
 
   // https://github.com/facebook/jest/issues/8297

--- a/src/index.js
+++ b/src/index.js
@@ -70,8 +70,9 @@ function patchJestAPI({
         onHandleError(delegate, current, target, e) {
           if (e && e[EXPOSE_ERROR]) {
             logger.warn(`${e.message}\n\n${stack.clean(e.stack)}`);
+            return false;
           }
-          return false;
+          throw e;
         },
         onInvokeTask(delegate, current, target, task, applyThis, applyArgs) {
           let error;


### PR DESCRIPTION
Discovered that this passes:
```
test('should definitely fail', () => {
  expect(true).toBe(false);
})
```
Rethrowing from `onHandleError` if `e[EXPOSE_ERROR]` is false (or not set) seems to fix this behavior, but I'm happy to look into this more if you think that's not the right fix.

Added tests for `test` and `it`.