### PR TITLE
Support jsdom environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,40 @@ leads to [assertions "leaking" accross different tests](https://github.com/faceb
 
 For default behavior, add the plugin to your setup files.
 
+## Supported Jest Environments
+
+- `jest-plugin-must-assert` - Default supported environment, `node`
+- `jest-plugin-must-assert/jsdom` - JSDOM environment support. Necessary for
+  mocking window task functions like `setTimeout` when using `jest-environment-jsdom`.
+  Useful for React tests.
+
 ## Use
+
+### For a specific test file
+
+You may import the plugin into any test file you need additional safeguard for async logic.
+
+```js
+import 'jest-plugin-must-assert';
+
+test('some logic', () => {
+  setTimeout(() => expect(1).toBe(2)); // will be caught by the plugin
+  ...
+});
+```
+
+### For entire test suite
+
+Alternatively, you can enable the plugin for an entire test suite by adding it
+to your jest configuration.
 
 ```js
 ...
 setupFilesAfterEnv: ['jest-plugin-must-assert'],
 ...
 ```
+
+### Manual configuration
 
 You may also extend the default behavior with the following, manual configuration.
 

--- a/e2e/failing-jsdom/README.md
+++ b/e2e/failing-jsdom/README.md
@@ -1,0 +1,5 @@
+## JSDOM
+
+These are test cases specific to how `jsdom` is used in Jest tests,
+specifically React tests. We need to ensure we load the browser version
+Zone.js mocks in this scenario, hence the different config & tests.

--- a/e2e/failing-jsdom/__tests__/index.js
+++ b/e2e/failing-jsdom/__tests__/index.js
@@ -1,0 +1,90 @@
+/**
+ * All of the tests should fail, due to the plugin inserting hasAssertions()
+ * before every test is executed
+ */
+
+test('no assertions, no code', () => {});
+
+test('synchronous failure', () => {
+  expect(true).toBe(false);
+});
+
+test('missed runtime assertion', () => {
+  const unused = () => expect(true).toBe(true);
+});
+
+test('missed rejected promise', () =>
+  Promise.reject().then(() => {
+    expect(true).toBe(true);
+  }));
+
+// https://github.com/facebook/jest/issues/8297
+test('unreturned promise assertions', () => {
+  Promise.resolve().then(() => {
+    expect(true).toBe(false);
+  });
+});
+
+test.only('assertions in missed macro-tasks', () => {
+  // setTimeout(fn, 0) won't work the way we want it to here, it'll still pass
+  // the test
+  setTimeout(() => {
+    expect(1 + 1).toBe(2);
+  }, 100);
+});
+
+test.only('assertions after done() callback', done => {
+  setTimeout(() => {
+    done();
+    setTimeout(() => {
+      expect(1 + 1).toBe(2);
+    });
+  });
+});
+
+test.only('assertions after done() callback (jest bugfix)', done => {
+  setTimeout(() => {
+    done();
+    setTimeout(() => {
+      expect(1 + 1).toBe(2);
+    });
+  });
+});
+
+test('assertions failing in setTimeout', done => {
+  setTimeout(() => {
+    expect(true).toBe(false);
+    // done cannot be called here due to a throw just above it
+    done();
+  });
+});
+
+describe('it() blocks work as test()', () => {
+  it('missed runtime assertion', () => {
+    const unused = () => expect(true).toBe(true);
+  });
+
+  it('synchronous failure', () => {
+    expect(true).toBe(false);
+  });
+
+  // https://github.com/facebook/jest/issues/8297
+  it('unreturned promise assertions', () => {
+    Promise.resolve().then(() => {
+      expect(true).toBe(true);
+    });
+  });
+
+  it('missed rejected promise', () =>
+    Promise.reject().then(() => {
+      expect(true).toBe(true);
+    }));
+
+  it('assertions in missed macro-tasks', () => {
+    // setTimeout(fn, 0) won't work by the way we want it to here, it'll still pass
+    // the test
+    setTimeout(() => {
+      expect(1 + 1).toBe(2);
+    }, 100);
+  });
+});

--- a/e2e/failing-jsdom/package.json
+++ b/e2e/failing-jsdom/package.json
@@ -1,0 +1,7 @@
+{
+  "jest": {
+    "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": ["../../jsdom"],
+    "testRunner": "jest-circus/runner"
+  }
+}

--- a/jsdom-manual.js
+++ b/jsdom-manual.js
@@ -1,0 +1,4 @@
+module.exports = (...args) => {
+  require('zone.js/dist/zone.min');
+  return require('./src')(...args);
+};

--- a/jsdom.js
+++ b/jsdom.js
@@ -1,0 +1,6 @@
+require('zone.js/dist/zone.min');
+const patchJestAPI = require('./src');
+
+patchJestAPI({
+  logger: console,
+});

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,10 +1,21 @@
 const runJest = require('../runJest');
 
 // A generous timeout as the e2e failing tests timeout in some cases (as intended)
-jest.setTimeout(8000);
+jest.setTimeout(10000);
 
-test('failing tests', async () => {
+test('failing tests - node env', async () => {
   const results = await runJest('e2e/failing');
+
+  const totalTestsExecuted =
+    results.json.numTotalTests - results.json.numPendingTests;
+  // We should have ran _some_ tets here
+  expect(totalTestsExecuted > 0).toBe(true);
+  // All tests that were executed should have failed
+  expect(results.json.numFailedTests).toBe(totalTestsExecuted);
+});
+
+test('failing tests - jsdom env', async () => {
+  const results = await runJest('e2e/failing-jsdom');
 
   const totalTestsExecuted =
     results.json.numTotalTests - results.json.numPendingTests;
@@ -18,7 +29,8 @@ test('passing tests', async () => {
   const results = await runJest('e2e/passing');
 
   const totalTestsExecuted =
-    results.json.numTotalTests - results.json.numPendingTests;
+    results.json.numTotalTests -
+    (results.json.numPendingTests + results.json.numTodoTests);
   // We should have ran _some_ tets here
   expect(totalTestsExecuted > 0).toBe(true);
   // All tests that were executed should have passed

--- a/test-harness.js
+++ b/test-harness.js
@@ -4,8 +4,15 @@
  */
 const runCLI = require('jest-cli').runCLI;
 
+const [env = 'node'] = process.argv.slice(2);
+const projectmap = {
+  node: './e2e/failing',
+  jsdom: './e2e/failing-jsdom',
+  passing: './e2e/passing',
+};
+
 const options = {
-  projects: ['./e2e/failing'],
+  projects: [projectmap[env]],
   watch: true,
 };
 


### PR DESCRIPTION
Apparently, global methods like `setTimeout` are not properly mocked by Zone.js when combined with a `jsdom` environment in Jest. 

Mainly due to the fact that we are using the default, "node" lib version of Zone.js. Technically, Zone.js is correctly mocking all the timers, but these are not being used because jsdom environment forces things like `setTimeout` to be used from the `global.window` object. The fix is to make an optional API just for `jsdom`, which then loads the Zone.js mocks for the browser (which jsdom is pretending to be here).
