### PR TITLE
Bugfix - Unhandled promise rejections should fail tests

### DIFF
--- a/e2e/failing/__tests__/index.js
+++ b/e2e/failing/__tests__/index.js
@@ -4,7 +4,7 @@
  */
 const wait = require('wait-for-expect');
 
-test('this', () => {
+test('unhandled promise rejections fail tests', () => {
   Promise.resolve().then(() => {
     throw new Error('oops');
   });

--- a/e2e/failing/__tests__/index.js
+++ b/e2e/failing/__tests__/index.js
@@ -2,6 +2,16 @@
  * All of the tests should fail, due to the plugin inserting hasAssertions()
  * before every test is executed
  */
+const wait = require('wait-for-expect');
+
+test('this', () => {
+  Promise.resolve().then(() => {
+    throw new Error('oops');
+  });
+  return wait(() => {
+    expect(1).toBe(1);
+  });
+});
 
 test('no assertions, no code', () => {});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-plugin-must-assert",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1660,8 +1660,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1682,14 +1681,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1704,20 +1701,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1834,8 +1828,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1847,7 +1840,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1862,7 +1854,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1870,14 +1861,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1896,7 +1885,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1977,8 +1965,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1990,7 +1977,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2076,8 +2062,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2113,7 +2098,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2133,7 +2117,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2177,14 +2160,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5095,6 +5076,12 @@
       "requires": {
         "browser-process-hrtime": "^0.1.2"
       }
+    },
+    "wait-for-expect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.1.tgz",
+      "integrity": "sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-plugin-must-assert",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Jest plugin for async tests",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "trailingComma": "es5"
   },
   "jest": {
-    "testEnvironment": "node",
+    "testEnvironment": "jsdom",
     "testRegex": "src/__tests__/.*|(\\.|/)(test|spec)\\.[jt]sx?$"
   },
   "devDependencies": {
@@ -28,7 +28,8 @@
     "jest-cli": "^24.7.1",
     "meow": "^5.0.0",
     "prettier": "^1.16.4",
-    "strip-ansi": "^5.2.0"
+    "strip-ansi": "^5.2.0",
+    "wait-for-expect": "^3.0.1"
   },
   "dependencies": {
     "stack-utils": "^1.0.2",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -4,23 +4,6 @@ const wait = require('wait-for-expect');
 // A generous timeout as the e2e failing tests timeout in some cases (as intended)
 jest.setTimeout(10000);
 
-test.only('this', () => {
-  let x = 0;
-  setTimeout(() => {
-    x = 1;
-  }, 1);
-  Promise.resolve().then(() => {
-    throw new Error('oops');
-  });
-  return wait(() => {
-    expect(x).toBe(1);
-  }).then(() => {});
-});
-
-test.only('should pass', () => {
-  expect(1).toBe(1);
-});
-
 test('failing tests - node env', async () => {
   const results = await runJest('e2e/failing');
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,7 +1,25 @@
 const runJest = require('../runJest');
+const wait = require('wait-for-expect');
 
 // A generous timeout as the e2e failing tests timeout in some cases (as intended)
 jest.setTimeout(10000);
+
+test.only('this', () => {
+  let x = 0;
+  setTimeout(() => {
+    x = 1;
+  }, 1);
+  Promise.resolve().then(() => {
+    throw new Error('oops');
+  });
+  return wait(() => {
+    expect(x).toBe(1);
+  }).then(() => {});
+});
+
+test.only('should pass', () => {
+  expect(1).toBe(1);
+});
 
 test('failing tests - node env', async () => {
   const results = await runJest('e2e/failing');

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,46 @@
+/**
+ * Implementation of Must assert plugin
+ *
+ * @author  Arthur Buldauskas <arthurbuldauskas@gmail.com>
+ */
 const StackUtils = require('stack-utils');
+
+// Default export
+//
+// The plugin does nothing unless this is invoked
 module.exports = patchJestAPI;
 
 const EXPOSE_ERROR = Symbol('EXPOSE_ERROR');
 
+/**
+ * Return true if object is a promise
+ *
+ * @return Boolean
+ */
+const isThenable = obj =>
+  typeof obj === 'object' && obj != null && typeof obj.then === 'function';
+
+/**
+ * Responds to task invokations. Default implementation
+ *
+ * @throws
+ *
+ * @return Boolean Whether or not the task should be allowed to run
+ */
 function onInvokeTaskDefault({
+  // The zone ID which originated this task
   originZoneId,
+  // The current global zone ID currently executing
   currentZoneId,
+  // The name of the test from where this task originates
   testName,
+  // The type of the task being acted upon [micro || macro]Task
   taskType,
+  // Promise, setTimeout etc.
   taskSource,
 }) {
+  // Note that we do not use "testName" for this as they are not guaranteed to be
+  // unique
   if (originZoneId !== currentZoneId) {
     throw new Error(
       `Test "${testName}" is attempting to invoke a ${taskType}(${taskSource}) after test completion. See stack-trace for details.`
@@ -18,52 +49,106 @@ function onInvokeTaskDefault({
   return true;
 }
 
+/**
+ * Path Jest test API
+ *
+ * We will wrap every supported Jest method so that we can place every test
+ * that is declared with it's own Zone. Each test will have it's own zone, which
+ * will have a unique ID. There will be one global "current" zone ID, whenever an
+ * async event attempts to invoke a callback which is NOT from the current zone
+ * ID we will block it and log a warning.
+ *
+ * @return void
+ */
 function patchJestAPI({
+  // Set your own onInvoke task handler if you don't like the original behavior
   onInvokeTask = onInvokeTaskDefault,
+  // Logger override
   logger = console,
-  ignoreStack = [],
+  // Regex of what should be REMOVED from the stack traces of cancelled tasks
+  ignoreStack = [/Zone/, /zone\.js/, /node_modules/],
 }) {
+  // Requiring Zone libraries here ensures that we allow for users of the
+  // plugin to conditionally add this functionally per test suite module.
+
+  // Zone will patch console for us, but we don't really want that
   const consoleMethods = Object.entries(global.console);
-  const restoreConsole = () =>
-    consoleMethods.forEach(([key, value]) => {
-      global.console[key] = value;
-    });
 
   require('zone.js');
   require('zone.js/dist/long-stack-trace-zone');
-  // NOTE: zone.js patches console methods, avoid that.
-  restoreConsole();
 
+  // Restore default console
+  consoleMethods.forEach(([key, value]) => {
+    global.console[key] = value;
+  });
+
+  // We clean the stacks to make them easier to reason about in the console output
   const stack = new StackUtils({
     cwd: process.cwd(),
-    internals: StackUtils.nodeInternals()
-      .concat([/Zone/, /zone\.js/, /node_modules/])
-      .concat(ignoreStack),
+    // Stack utils API for what functions should be removed from the stack trace
+    // We omit node_modules, Zone library and node internals by default
+    internals: StackUtils.nodeInternals().concat(ignoreStack),
   });
-  // Zone sets itself as a global...
+
+  // Zone sets itself as a global, that's just how the library works
   const Zone = global.Zone;
+  // The current zone. Every time a test starts this changes
   let currentZone = null;
+
+  // All zone ID should be unique
   let uniqueIdentifier = 0;
   const uuid = () => ++uniqueIdentifier;
 
+  /**
+   * Return whether or not the test which we are in has it's own expect.hasAssertions
+   * check defined.
+   *
+   * @return Boolean
+   */
   const testNeedsAssertionCheck = () => {
-    // Some misconfigured test (eg overriding expect itself)
+    // Safety check for misconfigured tests (eg overriding expect itself)
+    // Or a test runner which is not Jest
     if (!(typeof expect !== 'undefined' && 'getState' in expect)) {
       return false;
     }
+
+    // Jest keeps state as a global, exposes it on the expect API
     const state = expect.getState();
+
     return (
       typeof state.expectedAssertionsNumber !== 'number' &&
       !state.isExpectingAssertions
     );
   };
 
-  const exitZone = () => (currentZone = null);
+  /**
+   * Exit the current zone
+   *
+   * Only if it still matches the zone ID attempting to exit
+   *
+   */
+  const exitZone = id => {
+    if (id === currentZone) {
+      currentZone = null;
+    }
+  };
+
+  /**
+   * Enter a new zone
+   *
+   */
   const enterZone = (callback, name, hasDoneCallback) => {
     const id = uuid();
+
+    /**
+     * Create a new zone using Zone.js API
+     *
+     * See https://github.com/angular/angular/blob/master/packages/zone.js/lib/zone.ts
+     */
     const zone = Zone.root
       .fork({
         name,
+        // Attach the id to the zone object
         properties: {
           id,
         },
@@ -109,49 +194,96 @@ function patchJestAPI({
 
     currentZone = id;
 
-    return zone.wrap(hasDoneCallback ? callback : done => callback(done));
+    return [zone.wrap(hasDoneCallback ? callback : done => callback(done)), id];
   };
 
+  /**
+   * Wrap a test in a zone
+   *
+   * We will use the zone defined above to control async events spawning form this
+   * test
+   *
+   * @return Function
+   */
   const wrapTest = (fn, name) => {
-    let testMustAssert;
+    let testMustAssert, unhandledError;
     const hasDoneCallback = fn.length > 0;
 
-    if (!hasDoneCallback) {
-      return () => {
-        const result = enterZone(fn, name, false)();
+    const recordUnhandledException = e => (unhandledException = e);
+    const listenToExceptions = () =>
+      process.addListener('unhandledRejection', recordUnhandledException);
+    const cleanupListeners = () =>
+      process.removeListener('unhandledRejection', recordUnhandledException);
 
+    const [zonedTest, zoneId] = enterZone(fn, name, hasDoneCallback);
+
+    // Support done() callback style tests
+    if (hasDoneCallback) {
+      return (doneOriginal, ...args) => {
+        const done = () => {
+          exitZone(zoneId);
+          cleanupListeners();
+          doneOriginal();
+        };
+
+        listenToExceptions();
+
+        const result = zonedTest(done, ...args);
+
+        // If there were no assertion count checks, add them
         if (testNeedsAssertionCheck()) {
           expect.hasAssertions();
         }
 
-        if (
-          typeof result === 'object' &&
-          result != null &&
-          typeof result.then === 'function'
-        ) {
-          return result.then(exitZone, e => {
-            exitZone();
-            throw e;
-          });
-        }
-
-        exitZone();
         return result;
       };
     }
 
-    return (doneOriginal, ...args) => {
-      const done = () => {
-        exitZone();
-        doneOriginal();
-      };
-      const result = enterZone(fn, name, true)(done, ...args);
+    // If the test is NOT using a done callback run it as normal
+    return () => {
+      // Run the test
+      const result = zonedTest();
 
+      // If there were no assertion count checks, add them
       if (testNeedsAssertionCheck()) {
         expect.hasAssertions();
       }
 
-      return result;
+      // Not a promise returned from the test, exit zone and return the result
+      if (!isThenable(result)) {
+        exitZone(zoneId);
+        return result;
+      }
+
+      // If the test returned a promise, wait until it resolves before exiting
+      // the zone
+
+      // Listen to unhandledPromiseRejections to mirror jest behavior
+      //
+      // We will need to re-throw any errors found to make sure jest can
+      // still fail this test. This is default Jest behavior
+      listenToExceptions();
+
+      return result.then(
+        // Test promise resolved without issue
+        () => {
+          exitZone(zoneId);
+
+          cleanupListeners();
+
+          if (unhandledException) {
+            throw unhandledException;
+          }
+        },
+        // Test threw
+        e => {
+          cleanupListeners();
+
+          exitZone(zoneId);
+
+          throw e;
+        }
+      );
     };
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,21 +4,8 @@
  * @author  Arthur Buldauskas <arthurbuldauskas@gmail.com>
  */
 const StackUtils = require('stack-utils');
-
-// Default export
-//
-// The plugin does nothing unless this is invoked
-module.exports = patchJestAPI;
-
-const EXPOSE_ERROR = Symbol('EXPOSE_ERROR');
-
-/**
- * Return true if object is a promise
- *
- * @return Boolean
- */
-const isThenable = obj =>
-  typeof obj === 'object' && obj != null && typeof obj.then === 'function';
+const { getWrapper } = require('./wrap-test');
+const { getZones } = require('./zones');
 
 /**
  * Responds to task invokations. Default implementation
@@ -68,238 +55,16 @@ function patchJestAPI({
   // Regex of what should be REMOVED from the stack traces of cancelled tasks
   ignoreStack = [/Zone/, /zone\.js/, /node_modules/],
 }) {
-  // Requiring Zone libraries here ensures that we allow for users of the
-  // plugin to conditionally add this functionally per test suite module.
-
-  // Zone will patch console for us, but we don't really want that
-  const consoleMethods = Object.entries(global.console);
-
-  require('zone.js');
-  require('zone.js/dist/long-stack-trace-zone');
-
-  // Restore default console
-  consoleMethods.forEach(([key, value]) => {
-    global.console[key] = value;
+  const { enterZone, exitZone } = getZones({
+    onInvokeTask,
+    logger,
+    ignoreStack,
   });
+  const wrapTest = getWrapper({ enterZone, exitZone });
 
-  // We clean the stacks to make them easier to reason about in the console output
-  const stack = new StackUtils({
-    cwd: process.cwd(),
-    // Stack utils API for what functions should be removed from the stack trace
-    // We omit node_modules, Zone library and node internals by default
-    internals: StackUtils.nodeInternals().concat(ignoreStack),
-  });
-
-  // Zone sets itself as a global, that's just how the library works
-  const Zone = global.Zone;
-  // The current zone. Every time a test starts this changes
-  let currentZone = null;
-
-  // All zone ID should be unique
-  let uniqueIdentifier = 0;
-  const uuid = () => ++uniqueIdentifier;
-
-  /**
-   * Return whether or not the test which we are in has it's own expect.hasAssertions
-   * check defined.
-   *
-   * @return Boolean
-   */
-  const testNeedsAssertionCheck = () => {
-    // Safety check for misconfigured tests (eg overriding expect itself)
-    // Or a test runner which is not Jest
-    if (!(typeof expect !== 'undefined' && 'getState' in expect)) {
-      return false;
-    }
-
-    // Jest keeps state as a global, exposes it on the expect API
-    const state = expect.getState();
-
-    return (
-      typeof state.expectedAssertionsNumber !== 'number' &&
-      !state.isExpectingAssertions
-    );
-  };
-
-  /**
-   * Exit the current zone
-   *
-   * Only if it still matches the zone ID attempting to exit
-   *
-   */
-  const exitZone = id => {
-    if (id === currentZone) {
-      currentZone = null;
-    }
-  };
-
-  /**
-   * Enter a new zone
-   *
-   */
-  const enterZone = (callback, name, hasDoneCallback) => {
-    const id = uuid();
-
-    /**
-     * Create a new zone using Zone.js API
-     *
-     * See https://github.com/angular/angular/blob/master/packages/zone.js/lib/zone.ts
-     */
-    const zone = Zone.root
-      .fork({
-        name,
-        // Attach the id to the zone object
-        properties: {
-          id,
-        },
-        onHandleError(delegate, current, target, e) {
-          if (e && e[EXPOSE_ERROR]) {
-            logger.warn(`${e.message}\n\n${stack.clean(e.stack)}`);
-            return false;
-          }
-          throw e;
-        },
-        onInvokeTask(delegate, current, target, task, applyThis, applyArgs) {
-          let error;
-          let result = true;
-          try {
-            result = onInvokeTask({
-              originZoneId: current.get('id'),
-              currentZoneId: currentZone,
-              testName: name,
-              taskType: task.type,
-              taskSource: task.source,
-              logger: logger,
-            });
-          } catch (e) {
-            error = e;
-          }
-
-          if (error) {
-            error[EXPOSE_ERROR] = true;
-            error.task = task;
-            throw error;
-          }
-
-          if (!result) {
-            return;
-          }
-
-          return delegate.invokeTask(target, task, applyThis, applyArgs);
-        },
-      })
-      // We fork from the special stack-trace zone so that there is a trail leading
-      // back to the origin of the ignored tasks
-      .fork(Zone.longStackTraceZoneSpec);
-
-    const enter = () => (currentZone = id);
-
-    return [
-      zone.wrap(
-        hasDoneCallback
-          ? done => {
-              enter();
-              return callback(done);
-            }
-          : () => {
-              enter();
-              return callback();
-            }
-      ),
-      id,
-    ];
-  };
-
-  /**
-   * Wrap a test in a zone
-   *
-   * We will use the zone defined above to control async events spawning form this
-   * test
-   *
-   * @return Function
-   */
-  const wrapTest = (fn, name) => {
-    let testMustAssert, unhandledException;
-    const hasDoneCallback = fn.length > 0;
-
-    const recordUnhandledException = e => (unhandledException = e);
-    const listenToExceptions = () =>
-      process.addListener('unhandledRejection', recordUnhandledException);
-    const cleanupListeners = () =>
-      process.removeListener('unhandledRejection', recordUnhandledException);
-
-    const [zonedTest, zoneId] = enterZone(fn, name, hasDoneCallback);
-
-    // Support done() callback style tests
-    if (hasDoneCallback) {
-      return (doneOriginal, ...args) => {
-        const done = () => {
-          exitZone(zoneId);
-          cleanupListeners();
-          doneOriginal();
-        };
-
-        listenToExceptions();
-
-        const result = zonedTest(done, ...args);
-
-        // If there were no assertion count checks, add them
-        if (testNeedsAssertionCheck()) {
-          expect.hasAssertions();
-        }
-
-        return result;
-      };
-    }
-
-    // If the test is NOT using a done callback run it as normal
-    return () => {
-      // Run the test
-      const result = zonedTest();
-
-      // If there were no assertion count checks, add them
-      if (testNeedsAssertionCheck()) {
-        expect.hasAssertions();
-      }
-
-      // Not a promise returned from the test, exit zone and return the result
-      if (!isThenable(result)) {
-        exitZone(zoneId);
-        return result;
-      }
-
-      // If the test returned a promise, wait until it resolves before exiting
-      // the zone
-
-      // Listen to unhandledPromiseRejections to mirror jest behavior
-      //
-      // We will need to re-throw any errors found to make sure jest can
-      // still fail this test. This is default Jest behavior
-      listenToExceptions();
-
-      return result.then(
-        // Test promise resolved without issue
-        () => {
-          exitZone(zoneId);
-
-          cleanupListeners();
-
-          if (unhandledException) {
-            throw unhandledException;
-          }
-        },
-        // Test threw
-        e => {
-          cleanupListeners();
-
-          exitZone(zoneId);
-
-          throw e;
-        }
-      );
-    };
-  };
-
+  // TODO: Figure out a way to show the original test during errors instead of the
+  // wrapper below. AFAIK it's not doable unless we recompile the original fn and
+  // somehow append the extra checks...
   function enhanceJestImplementationWithAssertionCheck(jestTest) {
     return function ehanchedJestMehod(name, fn, timeout) {
       return jestTest(name, wrapTest(fn, name), timeout);
@@ -309,6 +74,7 @@ function patchJestAPI({
   // Create the enhanced version of the base test() method
   const enhancedTest = enhanceJestImplementationWithAssertionCheck(global.test);
 
+  // TODO: Support .each
   const donotpatch = ['each', 'skip', 'todo'];
 
   Object.keys(global.test).forEach(key => {
@@ -325,3 +91,8 @@ function patchJestAPI({
   global.fit = enhancedTest.only;
   global.test = enhancedTest;
 }
+
+// Default export
+//
+// The plugin does nothing unless this is invoked
+module.exports = patchJestAPI;

--- a/src/wrap-test.js
+++ b/src/wrap-test.js
@@ -1,0 +1,133 @@
+/**
+ * Test wrapper implementation
+ *
+ * @author Arthur Buldauskas<arthurbuldauskas@gmail.com>
+ */
+
+/**
+ * Return true if object is a promise
+ *
+ * @return Boolean
+ */
+const isThenable = obj =>
+  typeof obj === 'object' && obj != null && typeof obj.then === 'function';
+
+/**
+ * Return whether or not the test which we are in has it's own expect.hasAssertions
+ * check defined.
+ *
+ * @return Boolean
+ */
+const testNeedsAssertionCheck = () => {
+  // Safety check for misconfigured tests (eg overriding expect itself)
+  // Or a test runner which is not Jest
+  if (!(typeof expect !== 'undefined' && 'getState' in expect)) {
+    return false;
+  }
+
+  // Jest keeps state as a global, exposes it on the expect API
+  const state = expect.getState();
+
+  return (
+    typeof state.expectedAssertionsNumber !== 'number' &&
+    !state.isExpectingAssertions
+  );
+};
+
+const getWrapper = ({ enterZone, exitZone }) => {
+  /**
+   * Wrap a test in a zone
+   *
+   * We will use the zone defined above to control async events spawning form this
+   * test
+   *
+   * @return Function
+   */
+  const wrap = (fn, name) => {
+    let testMustAssert, unhandledException;
+    const hasDoneCallback = fn.length > 0;
+
+    const recordUnhandledException = e => (unhandledException = e);
+    const listenToExceptions = () =>
+      process.addListener('unhandledRejection', recordUnhandledException);
+    const cleanupListeners = () =>
+      process.removeListener('unhandledRejection', recordUnhandledException);
+
+    const [zonedTest, zoneId] = enterZone(fn, name, hasDoneCallback);
+
+    // Support done() callback style tests
+    if (hasDoneCallback) {
+      return (doneOriginal, ...args) => {
+        const done = () => {
+          exitZone(zoneId);
+          cleanupListeners();
+          doneOriginal();
+        };
+
+        listenToExceptions();
+
+        const result = zonedTest(done, ...args);
+
+        // If there were no assertion count checks, add them
+        if (testNeedsAssertionCheck()) {
+          expect.hasAssertions();
+        }
+
+        return result;
+      };
+    }
+
+    // If the test is NOT using a done callback run it as normal
+    return () => {
+      // Run the test
+      const result = zonedTest();
+
+      // If there were no assertion count checks, add them
+      if (testNeedsAssertionCheck()) {
+        expect.hasAssertions();
+      }
+
+      // Not a promise returned from the test, exit zone and return the result
+      if (!isThenable(result)) {
+        exitZone(zoneId);
+        return result;
+      }
+
+      // If the test returned a promise, wait until it resolves before exiting
+      // the zone
+
+      // Listen to unhandledPromiseRejections to mirror jest behavior
+      //
+      // We will need to re-throw any errors found to make sure jest can
+      // still fail this test. This is default Jest behavior
+      listenToExceptions();
+
+      return result.then(
+        // Test promise resolved without issue
+        () => {
+          exitZone(zoneId);
+
+          cleanupListeners();
+
+          if (unhandledException) {
+            throw unhandledException;
+          }
+        },
+        // Test threw
+        e => {
+          cleanupListeners();
+
+          exitZone(zoneId);
+
+          throw e;
+        }
+      );
+    };
+  };
+
+  return wrap;
+};
+
+module.exports = {
+  getWrapper,
+};

--- a/src/zones.js
+++ b/src/zones.js
@@ -1,0 +1,129 @@
+const StackUtils = require('stack-utils');
+
+const EXPOSE_ERROR = Symbol('EXPOSE_ERROR');
+
+const getZones = ({ onInvokeTask, logger, ignoreStack }) => {
+  // Requiring Zone libraries here ensures that we allow for users of the
+  // plugin to conditionally add this functionally per test suite module.
+
+  // Zone will patch console for us, but we don't really want that
+  const consoleMethods = Object.entries(global.console);
+
+  require('zone.js');
+  require('zone.js/dist/long-stack-trace-zone');
+
+  // Restore default console
+  consoleMethods.forEach(([key, value]) => {
+    global.console[key] = value;
+  });
+
+  // We clean the stacks to make them easier to reason about in the console output
+  const stack = new StackUtils({
+    cwd: process.cwd(),
+    // Stack utils API for what functions should be removed from the stack trace
+    // We omit node_modules, Zone library and node internals by default
+    internals: StackUtils.nodeInternals().concat(ignoreStack),
+  });
+
+  // Zone sets itself as a global, that's just how the library works
+  const Zone = global.Zone;
+  // The current zone. Every time a test starts this changes
+  let currentZone = null;
+
+  // All zone ID should be unique
+  let uniqueIdentifier = 0;
+  const uuid = () => ++uniqueIdentifier;
+
+  /**
+   * Exit the current zone
+   *
+   * Only if it still matches the zone ID attempting to exit
+   *
+   */
+  const exitZone = id => {
+    if (id === currentZone) {
+      currentZone = null;
+    }
+  };
+
+  /**
+   * Enter a new zone
+   *
+   */
+  const enterZone = (callback, name, hasDoneCallback) => {
+    const id = uuid();
+
+    /**
+     * Create a new zone using Zone.js API
+     *
+     * See https://github.com/angular/angular/blob/master/packages/zone.js/lib/zone.ts
+     */
+    const zone = Zone.root
+      .fork({
+        name,
+        // Attach the id to the zone object
+        properties: {
+          id,
+        },
+        onHandleError(delegate, current, target, e) {
+          if (e && e[EXPOSE_ERROR]) {
+            logger.warn(`${e.message}\n\n${stack.clean(e.stack)}`);
+            return false;
+          }
+          throw e;
+        },
+        onInvokeTask(delegate, current, target, task, applyThis, applyArgs) {
+          let error;
+          let result = true;
+          try {
+            result = onInvokeTask({
+              originZoneId: current.get('id'),
+              currentZoneId: currentZone,
+              testName: name,
+              taskType: task.type,
+              taskSource: task.source,
+              logger: logger,
+            });
+          } catch (e) {
+            error = e;
+          }
+
+          if (error) {
+            error[EXPOSE_ERROR] = true;
+            error.task = task;
+            throw error;
+          }
+
+          if (!result) {
+            return;
+          }
+
+          return delegate.invokeTask(target, task, applyThis, applyArgs);
+        },
+      })
+      // We fork from the special stack-trace zone so that there is a trail leading
+      // back to the origin of the ignored tasks
+      .fork(Zone.longStackTraceZoneSpec);
+
+    const enter = () => (currentZone = id);
+
+    return [
+      zone.wrap(
+        hasDoneCallback
+          ? done => {
+              enter();
+              return callback(done);
+            }
+          : () => {
+              enter();
+              return callback();
+            }
+      ),
+      id,
+    ];
+  };
+
+  return { enterZone, exitZone };
+};
+
+module.exports = { getZones };

--- a/src/zones.js
+++ b/src/zones.js
@@ -1,6 +1,19 @@
+/**
+ * Zoning helpers
+ *
+ * @author Arthur Buldauskas<arthurbuldauskas@gmail.com>
+ */
 const StackUtils = require('stack-utils');
 
 const EXPOSE_ERROR = Symbol('EXPOSE_ERROR');
+
+// Globals
+// The current zone. Every time a test starts this changes
+let currentZone = null;
+
+// All zone ID should be unique
+let uniqueIdentifier = 0;
+const uuid = () => ++uniqueIdentifier;
 
 const getZones = ({ onInvokeTask, logger, ignoreStack }) => {
   // Requiring Zone libraries here ensures that we allow for users of the
@@ -27,12 +40,6 @@ const getZones = ({ onInvokeTask, logger, ignoreStack }) => {
 
   // Zone sets itself as a global, that's just how the library works
   const Zone = global.Zone;
-  // The current zone. Every time a test starts this changes
-  let currentZone = null;
-
-  // All zone ID should be unique
-  let uniqueIdentifier = 0;
-  const uuid = () => ++uniqueIdentifier;
 
   /**
    * Exit the current zone


### PR DESCRIPTION
This change makes sure that unhandled promise rejections during an async test result in a failing test. This is something that Jest does out of the box and has regressed with the use of the plugin.

Added a ton of comments to the source.